### PR TITLE
SLING-12903 bump tika-core dependency to 1.28.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.17</version>
+            <version>1.28.3</version>
             <scope>provided</scope>
         </dependency>
         <!-- Apache Felix -->


### PR DESCRIPTION
bump tika-core dependency to 1.28.3 to resolve warnings about known security vulnerabilities